### PR TITLE
add getBytes method, able to reference index.html, header and footer by referring to string object

### DIFF
--- a/chrome.go
+++ b/chrome.go
@@ -49,11 +49,14 @@ type chromeRequest struct {
 	headerFilePath string
 	footerFilePath string
 
+	headerData string
+	footerData string
+
 	*request
 }
 
 func newChromeRequest() *chromeRequest {
-	return &chromeRequest{"", "", newRequest()}
+	return &chromeRequest{"", "", "", "", newRequest()}
 }
 
 // WaitDelay sets waitDelay form field.
@@ -67,6 +70,22 @@ func (req *chromeRequest) Header(fpath string) error {
 		return fmt.Errorf("%s: header file does not exist", fpath)
 	}
 	req.headerFilePath = fpath
+	return nil
+}
+
+func (req *chromeRequest) HeaderRaw(headerData string) error {
+	if len(headerData) == 0 {
+		return fmt.Errorf("header content is empty does not exist")
+	}
+	req.headerData = headerData
+	return nil
+}
+
+func (req *chromeRequest) FooterRaw(footerData string) error {
+	if len(footerData) == 0 {
+		return fmt.Errorf("footer content is empty does not exist")
+	}
+	req.footerData = footerData
 	return nil
 }
 
@@ -108,5 +127,10 @@ func (req *chromeRequest) formFiles() map[string]string {
 	files := make(map[string]string)
 	files["header.html"] = req.headerFilePath
 	files["footer.html"] = req.footerFilePath
+	return files
+}
+
+func (req *chromeRequest) formData() map[string]string {
+	files := make(map[string]string)
 	return files
 }

--- a/html_test.go
+++ b/html_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestHTML(t *testing.T) {
 	c := &Client{Hostname: "http://localhost:3000"}
-	req, err := NewHTMLRequest(test.HTMLTestFilePath(t, "index.html"))
+	req, err := NewHTMLRequest(test.HTMLTestFilePath(t, "index.html"), PathOption)
 	require.Nil(t, err)
 	req.ResultFilename("foo.pdf")
 	req.WaitTimeout(5)
@@ -41,9 +41,24 @@ func TestHTML(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestHTMLWithoutHeaderFooter(t *testing.T) {
+func TestHTMLRaw(t *testing.T) {
+
+	indexString := "<html><body><p>go filler text</p></body></html>"
+	newHeader := "<html><body><div>headtext</div></body></html>"
+
 	c := &Client{Hostname: "http://localhost:3000"}
-	req, err := NewHTMLRequest(test.HTMLTestFilePath(t, "index.html"))
+	req, err := NewHTMLRequest(test.HTMLTestFilePath(t, indexString), RawHTMLOption)
+	require.Nil(t, err)
+	req.ResultFilename("foo.pdf")
+	req.WaitTimeout(5)
+	req.WaitDelay(1)
+	err = req.HeaderRaw(test.HTMLTestFilePath(t, newHeader))
+	require.Nil(t, err)
+	err = req.Assets(
+		test.HTMLTestFilePath(t, "font.woff"),
+		test.HTMLTestFilePath(t, "img.gif"),
+		test.HTMLTestFilePath(t, "style.css"),
+	)
 	require.Nil(t, err)
 	req.PaperSize(A4)
 	req.Margins(NormalMargins)
@@ -56,5 +71,103 @@ func TestHTMLWithoutHeaderFooter(t *testing.T) {
 	assert.Nil(t, err)
 	assert.FileExists(t, dest)
 	err = os.RemoveAll(dirPath)
+	assert.Nil(t, err)
+}
+
+func TestHTMLWithoutHeaderFooter(t *testing.T) {
+	c := &Client{Hostname: "http://localhost:3000"}
+	req, err := NewHTMLRequest(test.HTMLTestFilePath(t, "index.html"), PathOption)
+	require.Nil(t, err)
+	req.PaperSize(A4)
+	req.Margins(NormalMargins)
+	req.Landscape(false)
+	req.GoogleChromeRpccBufferSize(1048576)
+	dirPath, err := test.Rand()
+	require.Nil(t, err)
+	dest := fmt.Sprintf("%s/foo.pdf", dirPath)
+	err = c.Store(req, dest)
+	assert.Nil(t, err)
+	assert.FileExists(t, dest)
+	err = os.RemoveAll(dirPath)
+	assert.Nil(t, err)
+}
+
+func TestHTMLWithGetByte(t *testing.T) {
+	c := &Client{Hostname: "http://localhost:3000"}
+	req, err := NewHTMLRequest(test.HTMLTestFilePath(t, "index.html"), PathOption)
+	require.Nil(t, err)
+	req.ResultFilename("foo.pdf")
+	req.WaitTimeout(5)
+	req.WaitDelay(1)
+	err = req.Header(test.HTMLTestFilePath(t, "header.html"))
+	require.Nil(t, err)
+	err = req.Footer(test.HTMLTestFilePath(t, "footer.html"))
+	require.Nil(t, err)
+	err = req.Assets(
+		test.HTMLTestFilePath(t, "font.woff"),
+		test.HTMLTestFilePath(t, "img.gif"),
+		test.HTMLTestFilePath(t, "style.css"),
+	)
+	require.Nil(t, err)
+	req.PaperSize(A4)
+	req.Margins(NormalMargins)
+	req.Landscape(false)
+	req.GoogleChromeRpccBufferSize(1048576)
+	pdfBytes, err := c.GetBytes(req)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, pdfBytes)
+	assert.True(t, (len(pdfBytes) > 120800))
+	assert.Contains(t, string(pdfBytes), "%PDF-1.4")
+	assert.Contains(t, string(pdfBytes), "/Width 287")
+	assert.Contains(t, string(pdfBytes), "/Height 320")
+	assert.Nil(t, err)
+}
+
+func TestHTMLStoreAndGetByte(t *testing.T) {
+	c := &Client{Hostname: "http://localhost:3000"}
+	req, err := NewHTMLRequest(test.HTMLTestFilePath(t, "index.html"), PathOption)
+	require.Nil(t, err)
+	req.ResultFilename("foo.pdf")
+	req.WaitTimeout(5)
+	req.WaitDelay(1)
+	err = req.Header(test.HTMLTestFilePath(t, "header.html"))
+	require.Nil(t, err)
+	err = req.Footer(test.HTMLTestFilePath(t, "footer.html"))
+	require.Nil(t, err)
+	err = req.Assets(
+		test.HTMLTestFilePath(t, "font.woff"),
+		test.HTMLTestFilePath(t, "img.gif"),
+		test.HTMLTestFilePath(t, "style.css"),
+	)
+	require.Nil(t, err)
+	req.PaperSize(A4)
+	req.Margins(NormalMargins)
+	req.Landscape(false)
+	req.GoogleChromeRpccBufferSize(1048576)
+	dirPath, err := test.Rand()
+	require.Nil(t, err)
+	dest := fmt.Sprintf("%s/foo.pdf", dirPath)
+	err = c.Store(req, dest)
+	assert.Nil(t, err)
+	assert.FileExists(t, dest)
+	err = os.RemoveAll(dirPath)
+	assert.Nil(t, err)
+	pdfBytes, err := c.GetBytes(req)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, pdfBytes)
+	assert.Nil(t, err)
+}
+
+func TestHTMLWithGetByteWithoutHeaderFooter(t *testing.T) {
+	c := &Client{Hostname: "http://localhost:3000"}
+	req, err := NewHTMLRequest(test.HTMLTestFilePath(t, "index.html"), PathOption)
+	require.Nil(t, err)
+	req.PaperSize(A4)
+	req.Margins(NormalMargins)
+	req.Landscape(false)
+	req.GoogleChromeRpccBufferSize(1048576)
+	pdfBytes, err := c.GetBytes(req)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, pdfBytes)
 	assert.Nil(t, err)
 }

--- a/markdown.go
+++ b/markdown.go
@@ -57,6 +57,11 @@ func (req *MarkdownRequest) formFiles() map[string]string {
 	return files
 }
 
+func (req *MarkdownRequest) formData() map[string]string {
+	files := make(map[string]string)
+	return files
+}
+
 // Compile-time checks to ensure type implements desired interfaces.
 var (
 	_ = Request(new(MarkdownRequest))

--- a/merge.go
+++ b/merge.go
@@ -35,6 +35,12 @@ func (req *MergeRequest) formFiles() map[string]string {
 	return files
 }
 
+func (req *MergeRequest) formData() map[string]string {
+	files := make(map[string]string)
+
+	return files
+}
+
 // Compile-time checks to ensure type implements desired interfaces.
 var (
 	_ = Request(new(MergeRequest))

--- a/office.go
+++ b/office.go
@@ -43,6 +43,12 @@ func (req *OfficeRequest) formFiles() map[string]string {
 	return files
 }
 
+func (req *OfficeRequest) formData() map[string]string {
+	files := make(map[string]string)
+
+	return files
+}
+
 // Compile-time checks to ensure type implements desired interfaces.
 var (
 	_ = Request(new(OfficeRequest))


### PR DESCRIPTION
Related to:
https://github.com/thecodingmachine/gotenberg-go-client/issues/9

Add references ability to reference header, footer and index html files using string variable within golang.

**Summary**

<!-- Summary of the PR -->

This PR implements the following 

* [x] NewHTMLRequest(newIndex string, HTMLOption string) **Modified** from NewHTMLRequest(newIndex string) - with newIndex referencing index.html filepath
* [x] HeaderRaw(newHeader string)
* [x] FooterRawRaw(newFooter string)
* [x] .GetBytes(req Request) ([]bytes, err)

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

This will eliminate the need to create and delete files for header.html, footer.html and index.html files and deleting them every-time, instead they can just be referenced by the html as a string

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Example on how to implement
```go

//declared index html string
indexString := "<html><body><p>go filler text</p></body></html>"

//declared header html string
newHeader := "<html><body><div>headtext</div></body></html>"

//if gotenberg docker api is running on default port:3000 - make the necessary connection

gotenbergClient := &gotenberg.Client{Hostname: "http://localhost:3000"}

//Newhtml request now will have a parameter for the choice to reference index.html
//either using gotenberg.RawHtmlOption (string value = "raw") - to reference raw html string
//or gotenberg.PathOption (string value = "path") to reference path string
//Note: path option will take precedence over raw option or path is not empty

reqPDF, _ := gotenberg.NewHTMLRequest(indexString, gotenberg.RawHtmlOption)
reqPDF.HeaderRaw(newHeader)
//footer can still be referenced by html filepath
reqPDF.Footer("footer.html")
//if reqPDF.FooterRaw(string) is referenced, it will 
//be ignored since footer by path is not empty

fileName := "myfile.pdf"

//store still stores the file locally
gotenbergClient.Store(reqPDF, fileName )

//however getbytes will get the entire html data as a byte[] type
pdfByteData, _:= gotenbergClient.GetBytes(reqPDF)
println(string(pdfByteData))

//we can also see the file pdf data in string format
// can be seem to start something like this

//%PDF-1.4
//%Óëéá
//1 0 obj
//<</Creator (Chromium)
//...

```

**Tests**
Added test cases to html_test.go
- [x] **TestHTMLRaw** - test that using raw string for index.html and header.html generates pdf file
- [x] **TestHTMLWithGetByte** - test that get byes returns pdf in byte[] - includes byte data and certain pdf string information for pdf doctype
- [x] **TestHTMLStoreAndGetByte** - test to make sure Store() and GetBytes() can still work one after the other
- [x] **TestHTMLWithGetByteWithoutHeaderFooter** - test to make sure GetBytes() works without header and footer file similar to the original TestHTMLWithoutHeaderFooter test with Store() 

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Partially implement feature request in - issue #9 for html to pdf conversion - have not implemented for other references such as asset files

**Checklist**

- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally (`make tests`)?
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code