### PR TITLE
Added "scale" option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ req.Footer(footer)
 req.Assets(style, img)
 req.PaperSize(gotenberg.A4)
 req.Margins(gotenberg.NoMargins)
+req.Scale(0.75)
 
 // store method allows you to... store the resulting PDF in a particular destination.
 client.Store(req, "path/you/want/the/pdf/to/be/stored.pdf")

--- a/chrome.go
+++ b/chrome.go
@@ -16,6 +16,7 @@ const (
 	landscapeChrome            string = "landscape"
 	pageRanges                 string = "pageRanges"
 	googleChromeRpccBufferSize string = "googleChromeRpccBufferSize"
+	scale                      string = "scale"
 )
 
 // nolint: gochecknoglobals
@@ -100,4 +101,9 @@ func (req *chromeRequest) PageRanges(ranges string) {
 // GoogleChromeRpccBufferSize sets googleChromeRpccBufferSize form field.
 func (req *chromeRequest) GoogleChromeRpccBufferSize(bufferSize int64) {
 	req.values[googleChromeRpccBufferSize] = strconv.FormatInt(bufferSize, 10)
+}
+
+// Scale sets scale form field
+func (req *chromeRequest) Scale(scaleFactor float64) {
+	req.values[scale] = fmt.Sprintf("%f", scaleFactor)
 }

--- a/html_test.go
+++ b/html_test.go
@@ -77,6 +77,7 @@ func TestHTMLComplete(t *testing.T) {
 	req.Margins(NormalMargins)
 	req.Landscape(false)
 	req.GoogleChromeRpccBufferSize(1048576)
+	req.Scale(1.5)
 	dirPath, err := test.Rand()
 	require.Nil(t, err)
 	dest := fmt.Sprintf("%s/foo.pdf", dirPath)


### PR DESCRIPTION
**Summary**

This PR fixes/implements the following **feature**:

* [X] Support for the "Scale" PDF print option ([related](https://github.com/thecodingmachine/gotenberg/pull/168))

**Test plan (required)**

```
$ make lint tests
docker build --build-arg GOLANG_VERSION=1.13 --build-arg GOLANGCI_LINT_VERSION=1.20.1 -t thecodingmachine/gotenberg-go-client:lint -f build/lint/Dockerfile .
Sending build context to Docker daemon  1.626MB

Step 1/9 : ARG GOLANG_VERSION
Step 2/9 : FROM golang:${GOLANG_VERSION}-stretch
 ---> ae9cd1729318
Step 3/9 : ARG GOLANGCI_LINT_VERSION
 ---> Using cache
 ---> 179247e3792b
Step 4/9 : RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b /usr/local/bin v${GOLANGCI_LINT_VERSION} &&    golangci-lint --version
 ---> Using cache
 ---> d6b8c36d6647
Step 5/9 : WORKDIR /lint
 ---> Using cache
 ---> 9c532f1c9c32
Step 6/9 : COPY go.mod .
 ---> Using cache
 ---> f5f28a46fe96
Step 7/9 : COPY go.sum .
 ---> Using cache
 ---> 62cd5634d8b2
Step 8/9 : RUN go mod download
 ---> Using cache
 ---> e4b6bf46718c
Step 9/9 : CMD [ "golangci-lint", "run" ,"--tests=false", "--enable-all", "--disable=dupl", "--disable=wsl" ]
 ---> Using cache
 ---> bf14224dd418
Successfully built bf14224dd418
Successfully tagged thecodingmachine/gotenberg-go-client:lint
docker run --rm -it -v "/home/matt/dev/experimental/gotenberg-go-client:/lint" thecodingmachine/gotenberg-go-client:lint
docker build --build-arg GOLANG_VERSION=1.13 --build-arg GOTENBERG_VERSION=6 --build-arg GOTENBERG_LOG_LEVEL=ERROR -t thecodingmachine/gotenberg-go-client:tests -f build/tests/Dockerfile .
Sending build context to Docker daemon  1.627MB

Step 1/17 : ARG GOLANG_VERSION
Step 2/17 : ARG GOTENBERG_VERSION
Step 3/17 : FROM golang:${GOLANG_VERSION}-stretch AS golang
 ---> ae9cd1729318
Step 4/17 : FROM thecodingmachine/gotenberg:${GOTENBERG_VERSION}
 ---> 5fd714815d6a
Step 5/17 : USER root
 ---> Using cache
 ---> f1ecfa36e0a3
Step 6/17 : RUN apt-get update &&    apt-get install -y git gcc
 ---> Using cache
 ---> 38fd9688840d
Step 7/17 : COPY --from=golang /usr/local/go /usr/local/go
 ---> Using cache
 ---> d87c06c93981
Step 8/17 : RUN export PATH="/usr/local/go/bin:$PATH" &&    go version
 ---> Using cache
 ---> 785911111c28
Step 9/17 : ENV GOPATH /go
 ---> Using cache
 ---> f9470f72e02e
Step 10/17 : ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 ---> Using cache
 ---> e1e34c0677b1
Step 11/17 : ARG GOTENBERG_LOG_LEVEL
 ---> Using cache
 ---> 62c657030c6c
Step 12/17 : ENV LOG_LEVEL=${GOTENBERG_LOG_LEVEL}
 ---> Using cache
 ---> 6ce0796d9cce
Step 13/17 : WORKDIR /tests
 ---> Using cache
 ---> fa2d878e7cc2
Step 14/17 : COPY go.mod .
 ---> Using cache
 ---> 260c87155ae1
Step 15/17 : COPY go.sum .
 ---> Using cache
 ---> bff4ddf39cf3
Step 16/17 : RUN go mod download
 ---> Using cache
 ---> 81169f4e8237
Step 17/17 : ENTRYPOINT [ "build/tests/docker-entrypoint.sh" ]
 ---> Using cache
 ---> 456baed2be0c
Successfully built 456baed2be0c
Successfully tagged thecodingmachine/gotenberg-go-client:tests
docker run --rm -it -v "/home/matt/dev/experimental/gotenberg-go-client:/tests" thecodingmachine/gotenberg-go-client:tests
+ sleep 10
+ gotenberg
+ go test -race -cover -covermode=atomic github.com/thecodingmachine/gotenberg-go-client/v7
ok  	github.com/thecodingmachine/gotenberg-go-client/v7	24.841s	coverage: 87.6% of statements
+ sleep 10
```

**Checklist**

- [X] Have you followed the guidelines in our [CONTRIBUTING](CONTRIBUTING.md) guide?
- [X] Have you lint your code locally prior to submission (`make lint`)?
- [X] Have you written new tests for your core changes, as applicable?
- [X] Have you successfully ran tests with your changes locally (`make tests`)?
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code