### PR TITLE
error return adjustment for client

### DIFF
--- a/client.go
+++ b/client.go
@@ -138,6 +138,11 @@ func (c *Client) StoreContext(ctx context.Context, req Request, dest string) err
 	if resp.StatusCode >= http.StatusBadRequest {
 		return fmt.Errorf("failed to generate the result PDF - http status code: [%d]", resp.StatusCode) // more details here now!
 	}
+	
+        if resp.StatusCode < http.StatusOK {
+		return log.Printf("http status code: [%d]") // maybe the gotenburg server is still processing the request etc - this could be passed through as a bool maybe.
+	}
+	
 	return writeNewFile(dest, resp.Body)
 }
 

--- a/client.go
+++ b/client.go
@@ -135,8 +135,8 @@ func (c *Client) StoreContext(ctx context.Context, req Request, dest string) err
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return errors.New("failed to generate the result PDF")
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("failed to generate the result PDF - http status code: [%d]", resp.StatusCode) // more details here now!
 	}
 	return writeNewFile(dest, resp.Body)
 }

--- a/client.go
+++ b/client.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"log"
 )
 
 const (


### PR DESCRIPTION
sometimes you get:

```failed to generate the result PDF```
in func (c *Client) StoreContext(ctx context.Context, req Request, dest string) error 

when you shouldn't.
I.E when the server is still processing a file.

so I did the below in a fork

https://github.com/tbal999/gotenberg-go-client/blob/48b3dc83b02f25f223a06bed4dc8cd51a2c18f60/client.go#L140

and it fixed the issue by returning an error & status if the status is an error.

could you please consider this PR.

thanks